### PR TITLE
Move prop-types to externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,7 @@ if (nodeEnv === 'development' || nodeEnv === 'demo') {
 
 if (nodeEnv === 'production') {
   webpackConfig.externals = {
+    'prop-types': 'prop-types',
     'react': {
       root: 'React',
       commonjs2: 'react',


### PR DESCRIPTION
Exclude `prop-types` from bundle moving the package to `externals`