### PR TITLE
Keep progress bar within 0 and 100

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -44,7 +44,7 @@ class CircularProgressbar extends React.Component {
     const diameter = Math.PI * 2 * radius;
     const progressStyle = {
       strokeDasharray: `${diameter}px ${diameter}px`,
-      strokeDashoffset: `${((100 - this.state.percentage) / 100 * diameter)}px`,
+      strokeDashoffset: `${((100 - Math.min(Math.max(this.state.percentage, 0), 100)) / 100 * diameter)}px`,
     };
 
     return (


### PR DESCRIPTION
## Expected behaviour
`<CircularProgressbar percentage={150} />` should show full progress bar. And the text should keep being `150%`
## Actual behaviour
`<CircularProgressbar percentage={150} />` shows half full progress bar