### PR TITLE
support classes prop

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -74,14 +74,14 @@ class CircularProgressbar extends React.Component {
   }
 
   render() {
-    const { percentage, textForPercentage, className, strokeWidth } = this.props;
+    const { percentage, textForPercentage, className, classes, strokeWidth } = this.props;
     const classForPercentage = this.props.classForPercentage ? this.props.classForPercentage(percentage) : '';
     const pathDescription = this.getPathDescription();
     const text = textForPercentage ? textForPercentage(percentage) : null;
 
     return (
       <svg
-        className={`CircularProgressbar ${className} ${classForPercentage}`}
+        className={`${classes.root} ${className} ${classForPercentage}`}
         viewBox="0 0 100 100"
       >
         {
@@ -96,14 +96,14 @@ class CircularProgressbar extends React.Component {
         }
 
         <path
-          className="CircularProgressbar-trail"
+          className={classes.trail}
           d={pathDescription}
           strokeWidth={strokeWidth}
           fillOpacity={0}
         />
 
         <path
-          className="CircularProgressbar-path"
+          className={classes.path}
           d={pathDescription}
           strokeWidth={strokeWidth}
           fillOpacity={0}
@@ -113,7 +113,7 @@ class CircularProgressbar extends React.Component {
         {
           text ? (
             <text
-              className="CircularProgressbar-text"
+              className={classes.text}
               x={50}
               y={50}
             >
@@ -129,6 +129,7 @@ class CircularProgressbar extends React.Component {
 CircularProgressbar.propTypes = {
   percentage: PropTypes.number.isRequired,
   className: PropTypes.string,
+  classes: PropTypes.object,
   strokeWidth: PropTypes.number,
   background: PropTypes.bool,
   backgroundPadding: PropTypes.number,
@@ -140,6 +141,12 @@ CircularProgressbar.propTypes = {
 CircularProgressbar.defaultProps = {
   strokeWidth: 8,
   className: '',
+  classes: {
+    root: 'CircularProgressbar',
+    trail: 'CircularProgressbar-trail',
+    path: 'CircularProgressbar-path',
+    text: 'CircularProgressbar-text',
+  },
   background: false,
   backgroundPadding: null,
   initialAnimation: false,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -129,7 +129,7 @@ class CircularProgressbar extends React.Component {
 CircularProgressbar.propTypes = {
   percentage: PropTypes.number.isRequired,
   className: PropTypes.string,
-  classes: PropTypes.object,
+  classes: PropTypes.objectOf(PropTypes.string),
   strokeWidth: PropTypes.number,
   background: PropTypes.bool,
   backgroundPadding: PropTypes.number,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -87,7 +87,7 @@ class CircularProgressbar extends React.Component {
         {
           this.props.background ? (
             <circle
-              className="CircularProgressbar-background"
+              className={classes.background}
               cx={50}
               cy={50}
               r={50}
@@ -146,6 +146,7 @@ CircularProgressbar.defaultProps = {
     trail: 'CircularProgressbar-trail',
     path: 'CircularProgressbar-path',
     text: 'CircularProgressbar-text',
+    background: 'CircularProgressbar-background',
   },
   background: false,
   backgroundPadding: null,


### PR DESCRIPTION
This allows passing a `classes` object, and extracts the current classes into the `defaultProp` value for it.  This makes it easy to use with `react-jss` instead of importing the given `styles.css`:

```js
import CircularProgress from 'react-circular-progressbar'
import injectSheet from 'react-jss'

const styles = {
  root: {
    width: '100%',
  },
  path: {
    stroke: '#3e98c7',
    strokeLinecap: 'round',
    transition: 'stroke-dashoffset 0.5s ease 0s',
  },
  trail: {
    stroke: '#d6d6d6',
  },
  {
    fill: '#3e98c7';
    fontSize: 20;
    dominantBaseline: 'middle',
    textAnchor: 'middle',
  },
}

export default injectSheet(styles)(CircularProgress)
```