### PR TITLE
Adds stackPercentages prop to allow for multi bar progress:

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a fork of Kevin Qi's react-circular-progressbar that adds support for mu
 ## Multibar usage
 
 ```js
-<CircularProgressbar percentage={0} percentages={[10, 20, 70]} />
+<CircularProgressbar percentage={0} stackPercentages={[10, 20, 70]} />
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# React Circular Progressbar
+# React Circular Multi Progressbar
+
+This is a fork of Kevin Qi's react-circular-progressbar that adds support for multiple bars within a single progressbar ring.
+
+## Multibar usage
+
+```js
+<CircularProgressbar percentage={0} percentages={[10, 20, 70]} />
+```
+
+
+## Original README follows
 
 A circular progress indicator component, built with SVG. Easily customizable with CSS. [See a live demo](http://www.kevinqi.com/react-circular-progressbar/).
 

--- a/docs/demo.jsx
+++ b/docs/demo.jsx
@@ -120,6 +120,21 @@ class Demo extends React.Component {
           </Example>
         </div>
 
+        <div className="row mt-3">
+
+          <Example
+            description="You can even stack percentages!"
+          >
+            <CircularProgressbar
+              initialAnimation
+              percentage={0}
+              stackPercentages={[10, 20, 45]}
+              textForPercentage={() => '75%'}
+            />
+          </Example>
+        </div>
+
+
         <hr />
         <div className="row mt-3 mb-3">
           <h2 className="text-xs-center">Installation</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,24 @@
       .CircularProgressbar.complete .CircularProgressbar-text {
         fill: #99f;
       }
+
+      .CircularProgressbar .CircularProgressbar-path-0 {
+        stroke: #f66;
+        stroke-linecap: round;
+        transition: stroke-dashoffset 0.5s ease 0s;
+      }
+
+      .CircularProgressbar .CircularProgressbar-path-1 {
+        stroke: #99f;
+        stroke-linecap: round;
+        transition: stroke-dashoffset 0.5s ease 0s;
+      }
+
+      .CircularProgressbar .CircularProgressbar-path-2 {
+        stroke: #3e98c7;
+        stroke-linecap: round;
+        transition: stroke-dashoffset 0.5s ease 0s;
+      }
     </style>
   </head>
   <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,19 +33,19 @@
         fill: #99f;
       }
 
-      .CircularProgressbar .CircularProgressbar-path-0 {
+      .CircularProgressbar .CircularProgressbar-path.path-0 {
         stroke: #f66;
         stroke-linecap: round;
         transition: stroke-dashoffset 0.5s ease 0s;
       }
 
-      .CircularProgressbar .CircularProgressbar-path-1 {
+      .CircularProgressbar .CircularProgressbar-path.path-1 {
         stroke: #99f;
         stroke-linecap: round;
         transition: stroke-dashoffset 0.5s ease 0s;
       }
 
-      .CircularProgressbar .CircularProgressbar-path-2 {
+      .CircularProgressbar .CircularProgressbar-path.path-2 {
         stroke: #3e98c7;
         stroke-linecap: round;
         transition: stroke-dashoffset 0.5s ease 0s;

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,19 +33,19 @@
         fill: #99f;
       }
 
-      .CircularProgressbar .CircularProgressbar-path.path-0 {
+      .CircularProgressbar .CircularProgressbar-path-0 {
         stroke: #f66;
         stroke-linecap: round;
         transition: stroke-dashoffset 0.5s ease 0s;
       }
 
-      .CircularProgressbar .CircularProgressbar-path.path-1 {
+      .CircularProgressbar .CircularProgressbar-path-1 {
         stroke: #99f;
         stroke-linecap: round;
         transition: stroke-dashoffset 0.5s ease 0s;
       }
 
-      .CircularProgressbar .CircularProgressbar-path.path-2 {
+      .CircularProgressbar .CircularProgressbar-path-2 {
         stroke: #3e98c7;
         stroke-linecap: round;
         transition: stroke-dashoffset 0.5s ease 0s;

--- a/docs/index.js
+++ b/docs/index.js
@@ -6629,7 +6629,7 @@ var CircularProgressbar = function (_React$Component) {
         }) : 0;
 
         return _react2.default.createElement('path', { key: 'path-' + idx,
-          className: 'CircularProgressbar-path-' + idx,
+          className: classes.path + ' path-' + idx,
           d: pathDescription,
           strokeWidth: strokeWidth,
           fillOpacity: 0,
@@ -10409,7 +10409,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-console.log('react-circular-progressbar v' + "0.6.2");
+console.log('react-circular-progressbar v' + "0.6.3");
 
 var githubURL = 'https://github.com/iqnivek/react-circular-progressbar';
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -6488,6 +6488,7 @@ var MAX_Y = 100;
 var FULL_RADIUS = 50;
 var CENTER_X = 50;
 var CENTER_Y = 50;
+var STACK_PREFIX = 'CircularProgressbar-path';
 
 var CircularProgressbar = function (_React$Component) {
   _inherits(CircularProgressbar, _React$Component);
@@ -6629,7 +6630,7 @@ var CircularProgressbar = function (_React$Component) {
         }) : 0;
 
         return _react2.default.createElement('path', { key: 'path-' + idx,
-          className: classes.path + ' path-' + idx,
+          className: '' + (classes.stackPaths[idx] || STACK_PREFIX + ('-' + idx)),
           d: pathDescription,
           strokeWidth: strokeWidth,
           fillOpacity: 0,
@@ -6700,7 +6701,8 @@ CircularProgressbar.defaultProps = {
     trail: 'CircularProgressbar-trail',
     path: 'CircularProgressbar-path',
     text: 'CircularProgressbar-text',
-    background: 'CircularProgressbar-background'
+    background: 'CircularProgressbar-background',
+    stackPaths: []
   },
   background: false,
   backgroundPadding: null,
@@ -10409,7 +10411,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-console.log('react-circular-progressbar v' + "0.6.3");
+console.log('react-circular-progressbar v' + "0.6.4");
 
 var githubURL = 'https://github.com/iqnivek/react-circular-progressbar';
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -6630,7 +6630,7 @@ var CircularProgressbar = function (_React$Component) {
         }) : 0;
 
         return _react2.default.createElement('path', { key: 'path-' + idx,
-          className: '' + (classes.stackPaths[idx] || STACK_PREFIX + ('-' + idx)),
+          className: '' + (classes.stackPaths && classes.stackPaths[idx] || STACK_PREFIX + ('-' + idx)),
           d: pathDescription,
           strokeWidth: strokeWidth,
           fillOpacity: 0,
@@ -10411,7 +10411,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-console.log('react-circular-progressbar v' + "0.6.4");
+console.log('react-circular-progressbar v' + "0.6.5");
 
 var githubURL = 'https://github.com/iqnivek/react-circular-progressbar';
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -6497,9 +6497,17 @@ var CircularProgressbar = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, (CircularProgressbar.__proto__ || Object.getPrototypeOf(CircularProgressbar)).call(this, props));
 
-    _this.state = {
+    var state = {
       percentage: props.initialAnimation ? 0 : props.percentage
     };
+
+    if (props.stackPercentages && Array.isArray(props.stackPercentages)) {
+      props.stackPercentages.forEach(function (p, idx) {
+        state['path-' + idx] = props.initialAnimation ? 0 : p;
+      });
+    }
+
+    _this.state = state;
     return _this;
   }
 
@@ -6511,9 +6519,17 @@ var CircularProgressbar = function (_React$Component) {
       if (this.props.initialAnimation) {
         this.initialTimeout = setTimeout(function () {
           _this2.requestAnimationFrame = window.requestAnimationFrame(function () {
-            _this2.setState({
+            var state = {
               percentage: _this2.props.percentage
-            });
+            };
+
+            if (_this2.props.stackPercentages && Array.isArray(_this2.props.stackPercentages)) {
+              _this2.props.stackPercentages.forEach(function (p, idx) {
+                return state['path-' + idx] = p;
+              });
+            }
+
+            _this2.setState(state);
           });
         }, 0);
       }
@@ -6521,9 +6537,17 @@ var CircularProgressbar = function (_React$Component) {
   }, {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(nextProps) {
-      this.setState({
+      var state = {
         percentage: nextProps.percentage
-      });
+      };
+
+      if (nextProps.stackPercentages && Array.isArray(nextProps.stackPercentages)) {
+        nextProps.stackPercentages.forEach(function (p, idx) {
+          return state['path-' + idx] = p;
+        });
+      }
+
+      this.setState(state);
     }
   }, {
     key: 'componentWillUnmount',
@@ -6560,13 +6584,19 @@ var CircularProgressbar = function (_React$Component) {
   }, {
     key: 'getProgressStyle',
     value: function getProgressStyle() {
+      var percentage = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.state.percentage;
+      var stackOffsetPercent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
+
       var diameter = Math.PI * 2 * this.getPathRadius();
-      var truncatedPercentage = Math.min(Math.max(this.state.percentage, MIN_PERCENTAGE), MAX_PERCENTAGE);
+      var truncatedPercentage = Math.min(Math.max(percentage, MIN_PERCENTAGE), MAX_PERCENTAGE);
       var dashoffset = (100 - truncatedPercentage) / 100 * diameter;
+      var stackOffsetDegrees = stackOffsetPercent / 100 * 360;
 
       return {
         strokeDasharray: diameter + 'px ' + diameter + 'px',
-        strokeDashoffset: (this.props.counterClockwise ? -dashoffset : dashoffset) + 'px'
+        strokeDashoffset: (this.props.counterClockwise ? -dashoffset : dashoffset) + 'px',
+        transformOrigin: 'center',
+        transform: 'rotate(' + stackOffsetDegrees + 'deg)'
       };
     }
   }, {
@@ -6579,8 +6609,11 @@ var CircularProgressbar = function (_React$Component) {
   }, {
     key: 'render',
     value: function render() {
+      var _this3 = this;
+
       var _props = this.props,
           percentage = _props.percentage,
+          stackPercentages = _props.stackPercentages,
           textForPercentage = _props.textForPercentage,
           className = _props.className,
           classes = _props.classes,
@@ -6589,6 +6622,20 @@ var CircularProgressbar = function (_React$Component) {
       var classForPercentage = this.props.classForPercentage ? this.props.classForPercentage(percentage) : '';
       var pathDescription = this.getPathDescription();
       var text = textForPercentage ? textForPercentage(percentage) : null;
+
+      var stackPercentagesPaths = stackPercentages ? stackPercentages.map(function (p, idx) {
+        var stackOffset = idx > 0 ? stackPercentages.slice(0, idx).reduce(function (acc, cur) {
+          return acc + cur;
+        }) : 0;
+
+        return _react2.default.createElement('path', { key: 'path-' + idx,
+          className: 'CircularProgressbar-path-' + idx,
+          d: pathDescription,
+          strokeWidth: strokeWidth,
+          fillOpacity: 0,
+          style: _this3.getProgressStyle(_this3.state['path-' + idx], stackOffset)
+        });
+      }) : null;
 
       return _react2.default.createElement(
         'svg',
@@ -6608,6 +6655,7 @@ var CircularProgressbar = function (_React$Component) {
           strokeWidth: strokeWidth,
           fillOpacity: 0
         }),
+        stackPercentagesPaths,
         _react2.default.createElement('path', {
           className: classes.path,
           d: pathDescription,
@@ -10361,7 +10409,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-console.log('react-circular-progressbar v' + "0.6.0");
+console.log('react-circular-progressbar v' + "0.6.2");
 
 var githubURL = 'https://github.com/iqnivek/react-circular-progressbar';
 
@@ -10454,12 +10502,12 @@ var Demo = function (_React$Component2) {
               _react2.default.createElement(
                 'h1',
                 { className: 'mb-2' },
-                "react-circular-progressbar"
+                "react-circular-multi-progressbar"
               ),
               _react2.default.createElement(
                 'p',
                 null,
-                "A circular progress indicator component"
+                "A circular progress indicator component with support for multiple bars"
               )
             )
           )
@@ -10547,6 +10595,24 @@ var Demo = function (_React$Component2) {
             )
           )
         ),
+        _react2.default.createElement(
+          'div',
+          { className: 'row mt-3' },
+          _react2.default.createElement(
+            Example,
+            {
+              description: 'You can even stack percentages!'
+            },
+            _react2.default.createElement(_src2.default, {
+              initialAnimation: true,
+              percentage: 0,
+              stackPercentages: [10, 20, 45],
+              textForPercentage: function textForPercentage() {
+                return '75%';
+              }
+            })
+          )
+        ),
         _react2.default.createElement('hr', null),
         _react2.default.createElement(
           'div',
@@ -10571,7 +10637,7 @@ var Demo = function (_React$Component2) {
                 'code',
                 null,
                 'npm install ',
-                "react-circular-progressbar"
+                "react-circular-multi-progressbar"
               )
             ),
             _react2.default.createElement(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-circular-multi-progressbar",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A circular progress indicator component with support for multiple bars",
   "author": "Kevin Qi <iqnivek@gmail.com>, Dave Martinez <d@dmartinez.co>",
   "main": "./build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "react-circular-progressbar",
-  "version": "0.6.0",
-  "description": "A circular progress indicator component",
-  "author": "Kevin Qi <iqnivek@gmail.com>",
+  "name": "react-circular-multi-progressbar",
+  "version": "0.6.1",
+  "description": "A circular progress indicator component with support for multiple bars",
+  "author": "Kevin Qi <iqnivek@gmail.com>, Dave Martinez <d@dmartinez.co>",
   "main": "./build/index.js",
-  "repository": "https://github.com/iqnivek/react-circular-progressbar.git",
+  "repository": "https://github.com/dmart914/react-circular-multi-progressbar.git",
   "license": "MIT",
   "keywords": [
     "progressbar",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-circular-multi-progressbar",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A circular progress indicator component with support for multiple bars",
   "author": "Kevin Qi <iqnivek@gmail.com>, Dave Martinez <d@dmartinez.co>",
   "main": "./build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-circular-multi-progressbar",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A circular progress indicator component with support for multiple bars",
   "author": "Kevin Qi <iqnivek@gmail.com>, Dave Martinez <d@dmartinez.co>",
   "main": "./build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-circular-multi-progressbar",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "A circular progress indicator component with support for multiple bars",
   "author": "Kevin Qi <iqnivek@gmail.com>, Dave Martinez <d@dmartinez.co>",
   "main": "./build/index.js",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -122,7 +122,7 @@ class CircularProgressbar extends React.Component {
 
         return (
           <path key={`path-${idx}`}
-            className={`CircularProgressbar-path-${idx}`}
+            className={`${classes.path} path-${idx}`}
             d={pathDescription}
             strokeWidth={strokeWidth}
             fillOpacity={0}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -123,7 +123,7 @@ class CircularProgressbar extends React.Component {
 
         return (
           <path key={`path-${idx}`}
-            className={`${classes.stackPaths[idx] || (STACK_PREFIX + `-${idx}`)}`}
+            className={`${classes.stackPaths && classes.stackPaths[idx] || (STACK_PREFIX + `-${idx}`)}`}
             d={pathDescription}
             strokeWidth={strokeWidth}
             fillOpacity={0}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,6 +8,7 @@ const MAX_Y = 100;
 const FULL_RADIUS = 50;
 const CENTER_X = 50;
 const CENTER_Y = 50;
+const STACK_PREFIX = 'CircularProgressbar-path';
 
 class CircularProgressbar extends React.Component {
   constructor(props) {
@@ -122,7 +123,7 @@ class CircularProgressbar extends React.Component {
 
         return (
           <path key={`path-${idx}`}
-            className={`${classes.path} path-${idx}`}
+            className={`${classes.stackPaths[idx] || (STACK_PREFIX + `-${idx}`)}`}
             d={pathDescription}
             strokeWidth={strokeWidth}
             fillOpacity={0}
@@ -203,6 +204,7 @@ CircularProgressbar.defaultProps = {
     path: 'CircularProgressbar-path',
     text: 'CircularProgressbar-text',
     background: 'CircularProgressbar-background',
+    stackPaths: []
   },
   background: false,
   backgroundPadding: null,


### PR DESCRIPTION
Hello! 

This is my first real pull request, so I apologize if I've done anything amateur!

This adds the ability to stack multiple percentages into a single bar. Perhaps you've got different resources loading at different rates, or you'd like to use this component as a pie chart. This allows you to pass in an array of integers as `stackPercentages` and see the pieces of the whole. 

If this is too far out of the purview of this component, I understand. 

Thanks for reviewing! :smile: 
  
Commit summary: 

- Refactors some state changes to create object, then apply to state
- Checks for prop stackPercentages during construction and
componentWillRecieveProps to handle animation
- Adds default to getProgressStyle for percentage as
this.state.percentage
- Adds param stackOffsetPercent to handle multibar percentages
- Adds transform styles to return value of getProgressStyle
- Adds stackPercenagesPaths to render method for multibar stack