### PR TITLE
Added styles prop to add inline styles to Progress objects

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -88,7 +88,7 @@ class CircularProgressbar extends React.Component {
   }
 
   render() {
-    const { percentage, textForPercentage, className, classes, strokeWidth } = this.props;
+    const { percentage, textForPercentage, className, classes, styles, strokeWidth } = this.props;
     const classForPercentage = this.props.classForPercentage ? this.props.classForPercentage(percentage) : '';
     const pathDescription = this.getPathDescription();
     const text = textForPercentage ? textForPercentage(percentage) : null;
@@ -102,6 +102,7 @@ class CircularProgressbar extends React.Component {
           this.props.background ? (
             <circle
               className={classes.background}
+              style={styles.background}
               cx={CENTER_X}
               cy={CENTER_Y}
               r={FULL_RADIUS}
@@ -111,6 +112,7 @@ class CircularProgressbar extends React.Component {
 
         <path
           className={classes.trail}
+          style={styles.trail}
           d={pathDescription}
           strokeWidth={strokeWidth}
           fillOpacity={0}
@@ -121,13 +123,14 @@ class CircularProgressbar extends React.Component {
           d={pathDescription}
           strokeWidth={strokeWidth}
           fillOpacity={0}
-          style={this.getProgressStyle()}
+          style={Object.assign({}, styles.path, this.getProgressStyle())}
         />
 
         {
           text ? (
             <text
               className={classes.text}
+              style={styles.text}
               x={CENTER_X}
               y={CENTER_Y}
             >
@@ -144,6 +147,7 @@ CircularProgressbar.propTypes = {
   percentage: PropTypes.number.isRequired,
   className: PropTypes.string,
   classes: PropTypes.objectOf(PropTypes.string),
+  styles: PropTypes.objectOf(PropTypes.object),
   strokeWidth: PropTypes.number,
   background: PropTypes.bool,
   backgroundPadding: PropTypes.number,
@@ -162,6 +166,13 @@ CircularProgressbar.defaultProps = {
     path: 'CircularProgressbar-path',
     text: 'CircularProgressbar-text',
     background: 'CircularProgressbar-background',
+  },
+  styles: {
+    root: {},
+    trail: {},
+    path: {},
+    text: {},
+    background: {},
   },
   background: false,
   backgroundPadding: null,


### PR DESCRIPTION
If you have a dynamic style to inject, you can not do it just by using classes, so I added a styles prop that you can use to overwrite basic CSS rules.
For instance, in my case, the path stroke color is calculated dynamically with a function like getHLS(percentage) => color, without a style prop I couldn't do that just by using CSS.